### PR TITLE
Separated the lightweight minimal code from the full featured version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 
-all: style
+all: base full
 
-style:
-	@lessc cssplot.less > cssplot.css
-	@echo "[!] cssplot.css generated"
+base:
+	@lessc cssplot.base.less > cssplot.base.css
+	@echo "[!] cssplot.base.css generated"
+
+full:
+	@lessc cssplot.full.less > cssplot.full.css
+	@echo "[!] cssplot.full.css generated"
 
 clean:
 	@rm -rf *.css
 
-.PHONY: all style clean
+.PHONY: all base full clean

--- a/cssplot.base.css
+++ b/cssplot.base.css
@@ -1,0 +1,63 @@
+.bar-chart,
+.vertical-chart,
+.scatterplot {
+  position: relative;
+  min-width: 100px;
+  min-height: 100px;
+  padding: 0;
+  margin: 0;
+}
+.bar-chart .container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  position: absolute;
+  text-align: center;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  padding: 0;
+  margin: 0;
+  min-height: 100px;
+}
+.bar-chart .chart-column {
+  flex-grow: 1;
+  align-self: flex-end;
+}
+.bar-chart .chart-column,
+.vertical-chart .chart-row {
+  background: #3498db;
+  color: #FFFFFF;
+  list-style: none;
+  border: 1px solid #FFFFFF;
+  box-sizing: border-box;
+}
+.vertical-chart {
+  clear: both;
+}
+.vertical-chart .container {
+  flex-direction: row;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+}
+.scatterplot .container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0;
+  padding: 0;
+}
+.scatterplot .chart-dot,
+.scatterplot .chart-dot {
+  position: absolute;
+  height: 0;
+  width: 0;
+  list-style: none;
+  overflow: hidden;
+  border: 6px solid #3498db;
+  border-radius: 100%;
+}

--- a/cssplot.base.less
+++ b/cssplot.base.less
@@ -1,24 +1,3 @@
-
-.height_loop(@percent_counter) when (@percent_counter >= 0) {
-  .height_loop((@percent_counter - 1));
-  [data-cp-size="@{percent_counter}"] { height: ~"@{percent_counter}%"; };
-}
-
-.width_loop(@percent_counter) when (@percent_counter >= 0) {
-  .width_loop((@percent_counter - 1));
-  [data-cp-size="@{percent_counter}"] { width: ~"@{percent_counter}%"; };
-}
-
-.x_loop(@percent_counter) when (@percent_counter >= 0) {
-  .x_loop((@percent_counter - 1));
-  [data-cp-x="@{percent_counter}"] { left: ~"@{percent_counter}%"; };
-}
-
-.y_loop(@percent_counter) when (@percent_counter >= 0) {
-  .y_loop((@percent_counter - 1));
-  [data-cp-y="@{percent_counter}"] { bottom: ~"@{percent_counter}%"; };
-}
-
 .bar-chart, .vertical-chart, .scatterplot {
     position: relative;
     min-width: 100px;
@@ -28,7 +7,6 @@
 }
 
 .bar-chart .container {
-    .height_loop(100);
     display: flex;
     flex-direction: row;
     flex-wrap: nowrap;
@@ -40,13 +18,13 @@
     min-height: 100px;
 }
 
-.bar-chart [data-cp-size] {
+.bar-chart .chart-column {
     flex-grow: 1;
     align-self: flex-end;
 }
 
-.bar-chart [data-cp-size],
-.vertical-chart [data-cp-size] {
+.bar-chart .chart-column,
+.vertical-chart .chart-row {
     background: #3498db;
     color: #FFFFFF;
     list-style: none;
@@ -59,7 +37,6 @@
 }
 
 .vertical-chart .container {
-    .width_loop(100);
     flex-direction: row;
     padding: 0;
     margin: 0;
@@ -67,8 +44,6 @@
 }
 
 .scatterplot .container {
-    .x_loop(100);
-    .y_loop(100);
     position: absolute;
     top: 0;
     left: 0;
@@ -77,8 +52,8 @@
     margin: 0; padding: 0;
 }
 
-.scatterplot [data-cp-x],
-.scatterplot [data-cp-y] {
+.scatterplot .chart-dot,
+.scatterplot .chart-dot {
     position: absolute;
     height: 0;
     width: 0;

--- a/cssplot.full.css
+++ b/cssplot.full.css
@@ -21,6 +21,46 @@
   margin: 0;
   min-height: 100px;
 }
+.bar-chart .chart-column {
+  flex-grow: 1;
+  align-self: flex-end;
+}
+.bar-chart .chart-column,
+.vertical-chart .chart-row {
+  background: #3498db;
+  color: #FFFFFF;
+  list-style: none;
+  border: 1px solid #FFFFFF;
+  box-sizing: border-box;
+}
+.vertical-chart {
+  clear: both;
+}
+.vertical-chart .container {
+  flex-direction: row;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+}
+.scatterplot .container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  margin: 0;
+  padding: 0;
+}
+.scatterplot .chart-dot,
+.scatterplot .chart-dot {
+  position: absolute;
+  height: 0;
+  width: 0;
+  list-style: none;
+  overflow: hidden;
+  border: 6px solid #3498db;
+  border-radius: 100%;
+}
 .bar-chart .container [data-cp-size="0"] {
   height: 0%;
 }
@@ -324,27 +364,6 @@
 .bar-chart .container [data-cp-size="100"] {
   height: 100%;
 }
-.bar-chart [data-cp-size] {
-  flex-grow: 1;
-  align-self: flex-end;
-}
-.bar-chart [data-cp-size],
-.vertical-chart [data-cp-size] {
-  background: #3498db;
-  color: #FFFFFF;
-  list-style: none;
-  border: 1px solid #FFFFFF;
-  box-sizing: border-box;
-}
-.vertical-chart {
-  clear: both;
-}
-.vertical-chart .container {
-  flex-direction: row;
-  padding: 0;
-  margin: 0;
-  width: 100%;
-}
 .vertical-chart .container [data-cp-size="0"] {
   width: 0%;
 }
@@ -647,15 +666,6 @@
 }
 .vertical-chart .container [data-cp-size="100"] {
   width: 100%;
-}
-.scatterplot .container {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin: 0;
-  padding: 0;
 }
 .scatterplot .container [data-cp-x="0"] {
   left: 0%;
@@ -1262,14 +1272,4 @@
 }
 .scatterplot .container [data-cp-y="100"] {
   bottom: 100%;
-}
-.scatterplot [data-cp-x],
-.scatterplot [data-cp-y] {
-  position: absolute;
-  height: 0;
-  width: 0;
-  list-style: none;
-  overflow: hidden;
-  border: 6px solid #3498db;
-  border-radius: 100%;
 }

--- a/cssplot.full.less
+++ b/cssplot.full.less
@@ -1,0 +1,34 @@
+@import "cssplot.base.less";
+
+.height_loop(@percent_counter) when (@percent_counter >= 0) {
+  .height_loop((@percent_counter - 1));
+  [data-cp-size="@{percent_counter}"] { height: ~"@{percent_counter}%"; };
+}
+
+.width_loop(@percent_counter) when (@percent_counter >= 0) {
+  .width_loop((@percent_counter - 1));
+  [data-cp-size="@{percent_counter}"] { width: ~"@{percent_counter}%"; };
+}
+
+.x_loop(@percent_counter) when (@percent_counter >= 0) {
+  .x_loop((@percent_counter - 1));
+  [data-cp-x="@{percent_counter}"] { left: ~"@{percent_counter}%"; };
+}
+
+.y_loop(@percent_counter) when (@percent_counter >= 0) {
+  .y_loop((@percent_counter - 1));
+  [data-cp-y="@{percent_counter}"] { bottom: ~"@{percent_counter}%"; };
+}
+
+.bar-chart .container {
+  .height_loop(100);
+}
+
+.vertical-chart .container {
+  .width_loop(100);
+}
+
+.scatterplot .container {
+  .x_loop(100);
+  .y_loop(100);
+}


### PR DESCRIPTION
Since those loops generate a quite heavy code, motivated by judofyr's comment on Hacker News (https://news.ycombinator.com/item?id=8500553), here's a new Makefile that generates both a lightweight version which requires inline CSS to work, and a full featured version that has better semantics, but is heavier.
