### PR TITLE
Group values and display them in different colors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-all: base full
+all: base full group
 
 base:
 	@lessc cssplot.base.less > cssplot.base.css
@@ -8,6 +8,10 @@ base:
 full:
 	@lessc cssplot.full.less > cssplot.full.css
 	@echo "[!] cssplot.full.css generated"
+
+group:
+	@lessc cssplot.group.less > cssplot.group.css
+	@echo "[!] cssplot.group.css generated"
 
 clean:
 	@rm -rf *.css

--- a/cssplot.base.css
+++ b/cssplot.base.css
@@ -31,9 +31,9 @@
 .bar-chart [data-cp-size],
 .vertical-chart [data-cp-size] {
   background: #3498db;
-  color: #FFFFFF;
+  color: #ffffff;
   list-style: none;
-  border: 1px solid #FFFFFF;
+  border: 1px solid #ffffff;
   box-sizing: border-box;
 }
 .vertical-chart {

--- a/cssplot.full.css
+++ b/cssplot.full.css
@@ -31,9 +31,9 @@
 .bar-chart [data-cp-size],
 .vertical-chart [data-cp-size] {
   background: #3498db;
-  color: #FFFFFF;
+  color: #ffffff;
   list-style: none;
-  border: 1px solid #FFFFFF;
+  border: 1px solid #ffffff;
   box-sizing: border-box;
 }
 .vertical-chart {

--- a/cssplot.group.css
+++ b/cssplot.group.css
@@ -1,0 +1,32 @@
+.group-by-gender .male {
+  background: #3498db;
+  color: #ffffff;
+}
+.group-by-gender .female {
+  background: #ff6699;
+  color: #ffffff;
+}
+.group-by-number [data-group="0"] {
+  background: #3498db;
+  color: #ffffff;
+}
+.group-by-number [data-group="1"] {
+  background: #ff6699;
+  color: #ffffff;
+}
+.group-by-number [data-group="2"] {
+  background: #93b881;
+  color: #ffffff;
+}
+.group-by-number [data-group="3"] {
+  background: #e09e87;
+  color: #ffffff;
+}
+.group-by-number [data-group="4"] {
+  background: #a22041;
+  color: #ffffff;
+}
+.group-by-number [data-group="5"] {
+  background: #95879c;
+  color: #ffffff;
+}

--- a/cssplot.group.less
+++ b/cssplot.group.less
@@ -1,0 +1,2 @@
+@import "defaults.less";
+@import "group.less";

--- a/defaults.less
+++ b/defaults.less
@@ -1,3 +1,13 @@
 @chart-primary-color: #3498db;
 @chart-primary-label-color: #FFFFFF;
 @chart-primary-border-color: #FFFFFF;
+@chart-secondary-color: #ff6699;
+@chart-secondary-label-color: @chart-primary-label-color;
+@chart-group2-color: #93b881;
+@chart-group2-label-color: @chart-primary-label-color;
+@chart-group3-color: #e09e87;
+@chart-group3-label-color: @chart-primary-label-color;
+@chart-group4-color: #a22041;
+@chart-group4-label-color: @chart-primary-label-color;
+@chart-group5-color: #95879c;
+@chart-group5-label-color: @chart-primary-label-color;

--- a/group.less
+++ b/group.less
@@ -1,0 +1,43 @@
+.group-by-gender {
+    .male {
+        background: @chart-primary-color;
+        color: @chart-primary-label-color;
+    }
+
+    .female {
+        background: @chart-secondary-color;
+        color: @chart-secondary-label-color;
+    }
+}
+
+.group-by-number {
+    [data-group="0"] {
+        background: @chart-primary-color;
+        color: @chart-primary-label-color;
+    }
+
+    [data-group="1"] {
+        background: @chart-secondary-color;
+        color: @chart-secondary-label-color;
+    }
+
+    [data-group="2"] {
+        background: @chart-group2-color;
+        color: @chart-group2-label-color;
+    }
+
+    [data-group="3"] {
+        background: @chart-group3-color;
+        color: @chart-group3-label-color;
+    }
+
+    [data-group="4"] {
+        background: @chart-group4-color;
+        color: @chart-group4-label-color;
+    }
+
+    [data-group="5"] {
+        background: @chart-group5-color;
+        color: @chart-group5-label-color;
+    }
+}


### PR DESCRIPTION
Many charts display groups in addition to numbers.

To implement this, I've created  a separete cssplot.groups.less file, which actually doesn't depend on cssplot.base.less, so can be universally used to display groupings.

It might also be useful when creating graphs.

An example code:

```
<div class="bar-chart group-by-gender">
    <ul class="container">
        <li data-cp-size="99" class=male>99%</li>
        <li data-cp-size="50" class=female>50%</li>
        <li data-cp-size="30" class=male>30%</li>
        <li data-cp-size="90" class=female>90%</li>
        <li data-cp-size="10" class=female>10%</li>
        <li data-cp-size="70" class=male>70%</li>
        <li data-cp-size="30" class=male>30%</li>
        <li data-cp-size="90" class=male>90%</li>
    </ul>
</div>

<div class="bar-chart group-by-number">
    <ul class="container">
        <li data-cp-size="99" data-group=0>99%</li>
        <li data-cp-size="50" data-group=1>50%</li>
        <li data-cp-size="30" data-group=2>30%</li>
        <li data-cp-size="90" data-group=3>90%</li>
        <li data-cp-size="10" data-group=4>10%</li>
        <li data-cp-size="70" data-group=5>70%</li>
        <li data-cp-size="30" data-group=6>30%</li>
        <li data-cp-size="90" data-group=0>90%</li>
    </ul>
</div>
```
